### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # minimal-action
 
 An action to test actions. It's the least an action can do: it accepts a file as input
-and writes the same file as output, with the suffix "bak" before the final suffix.
+and writes the same file as output, with a configurable suffix (".bak" by default) before the final suffix.
 
 ```yaml
 actions:

--- a/action/__main__.py
+++ b/action/__main__.py
@@ -16,7 +16,7 @@ def backup(input_file, config):
     backup exists, then it will be overwritten.
 
     Args:
-        input_file: A `pathlib.Path` representing the file to backup.
+        input_file: `pathlib.Path` representing the file to backup
         config: Dictionary of configuration values
 
     Raises:


### PR DESCRIPTION
There's a small amount of repetition between README and the docstring for `backup`. We changed the latter, so we should also change the former.